### PR TITLE
 replace QtConcurrent include with QtCore

### DIFF
--- a/passwordlistgenerator.cpp
+++ b/passwordlistgenerator.cpp
@@ -24,7 +24,7 @@
 #include <QDebug>
 #include <QHash>
 #include <QFuture>
-#include <QtConcurrent>
+#include <QtCore>
 
 QString ucFirst(const QString str) {
     if (str.size() < 1) {


### PR DESCRIPTION
Just had an exception (QtConcurrent not found) with a qt4.8 build...
QtConcurrent is now a namespace included in the QtCore include.
